### PR TITLE
Use container for building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
     steps:
       - name: "Set vars for build only if not on main"
         run: |
@@ -15,7 +17,10 @@ jobs:
           echo "PAGES_BRANCH=gh-pages" >> $GITHUB_ENV
         if: github.ref == 'refs/heads/main'
       - name: 'Install cargo'
-        run: sudo apt-get install -qy cargo
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -qy cargo
       - name: 'Install mdbook & svgbob'
         run: cargo install mdbook mdbook-svgbob
       - name: 'Checkout'
@@ -28,12 +33,12 @@ jobs:
           token: ${{ secrets.ACTBOT_PAT }}
       - name: 'Build acton-by-example'
         run: |
-          export PATH=/.cargo/bin:$PATH
+          export PATH=/github/home/.cargo/bin:$PATH
           cd acton/docs/acton-by-example
           mdbook build -d ../../../static/learn/acton-by-example
       - name: 'Build and deploy'
         uses: shalzz/zola-deploy-action@master
         env:
-          BUILD_DIR: .
+          BUILD_DIR: /github/workspace/acton/docs/acton-by-example
           TOKEN: ${{ secrets.ACTBOT_PAT }}
           PAGES_BRANCH: ${{ env.PAGES_BRANCH }}


### PR DESCRIPTION
Having problems with rust in the ubuntu-latest VM in GitHub Actions that I can't reproduce elsewhere on Ubuntu 20.04 (what ubuntu-latest currently maps to) so making the environment more deterministic by using a container.

We're on bookworm because 11 (bullseye) doesn't have a new enough rust / cargo for like anything? to work.